### PR TITLE
_DictMapping & ComplexObject both inherit MutableMapping

### DIFF
--- a/c8y_api/model/_base.py
+++ b/c8y_api/model/_base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Iterable, Set
 
+from collections.abc import MutableMapping
 from deprecated import deprecated
 from urllib.parse import urlencode
 
@@ -17,7 +18,7 @@ from c8y_api._base_api import CumulocityRestApi
 from c8y_api.model._util import _DateUtil
 
 
-class _DictWrapper(object):
+class _DictWrapper(MutableMapping):
 
     def __init__(self, dictionary, on_update=None):
         self.__dict__['items'] = dictionary
@@ -27,14 +28,34 @@ class _DictWrapper(object):
         """Check whether a key is present in the dictionary."""
         return name in self.items
 
-    def __getattr__(self, name):
+    def __getitem__(self, name):
         item = self.items[name]
         return item if not isinstance(item, dict) else _DictWrapper(item, self.on_update)
+
+    def __setitem__(self, name, value):
+        self.items[name] = value
+
+    def __delitem__(self, _):
+        raise NotImplementedError
+
+    def __iter__(self):
+        return iter(self.items)
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            ) from None
 
     def __setattr__(self, name, value):
         if self.on_update:
             self.on_update()
-        self.items[name] = value
+        self[name] = value
 
     def __str__(self):
         return self.__dict__['items'].__str__()
@@ -276,7 +297,7 @@ class SimpleObject(CumulocityObject):
         self.c8y.delete(self._build_object_path())
 
 
-class ComplexObject(SimpleObject, dict):
+class ComplexObject(SimpleObject, MutableMapping):
     """Abstract base class for all complex cumulocity objects
     (that can have custom fragments)."""
 
@@ -337,7 +358,7 @@ class ComplexObject(SimpleObject, dict):
         :param name: Name of the custom fragment
         """
         try:
-            return self.__getitem__(name)
+            return self[name]
         except KeyError:
             raise AttributeError(
                 f"'{type(self).__name__}' object has no attribute '{name}'"
@@ -345,7 +366,7 @@ class ComplexObject(SimpleObject, dict):
 
     def _setattr_(self, name, value):
         if name in self.fragments:
-            self.__setitem__(name, value)
+            self[name] = value
         else:
             object.__setattr__(self, name, value)
 
@@ -411,17 +432,14 @@ class ComplexObject(SimpleObject, dict):
         result.c8y = self.c8y
         return result
 
-    def items(self):
-        """Returns the objects' fragments as dictionary items."""
-        return self.fragments.items()
+    def __delitem__(self, _):
+        raise NotImplementedError
 
-    def keys(self):
-        """Returns the objects' fragment names."""
-        return self.fragments.keys()
+    def __iter__(self):
+        return iter(self.fragments)
 
-    def values(self):
-        """Returns the objects' fragment values."""
-        return self.fragments.values()
+    def __len__(self):
+        return len(self.fragments)
 
 
 class CumulocityResource:

--- a/c8y_api/model/measurements.py
+++ b/c8y_api/model/measurements.py
@@ -166,9 +166,9 @@ class Measurement(ComplexObject):
             measurement_json['time'] = _DateUtil.to_timestring(_DateUtil.now())
         return measurement_json
 
-    # the __getattr__ function is overwritten to return a wrapper that doesn't signal updates
+    # the __getitem__ function is overwritten to return a wrapper that doesn't signal updates
     # (because Measurements are not updated, can only be created from scratch)
-    def __getattr__(self, item):
+    def __getitem__(self, item):
         return _DictWrapper(self.fragments[item], on_update=None)
 
     @property


### PR DESCRIPTION
ComplexObject inheriting built-in 'dict' meant its __repr__ would always be an empty dictionary.

Instead we inherit MutableMapping to have more control over behaviour and still be able to use dict-like methods.

_DictMapping also inherits MutableMapping to have access to dict-like methods.