### PR TITLE
Feature/query improvements

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -19,4 +19,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --rcfile pylintrc --fail-under=9 c8y_api tests integration_tests
+        pylint --rcfile pylintrc --fail-under=9 c8y_api c8y_tk tests integration_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+* The `select` and `get_all` functions now feature an `expression` parameter which allows to directly specify the entire REST API filtering expression.
+* Fixed, unified and streamlined the behavior or the `query` parameter within all `select` and `get_all` functions.
+* The `apply_to` functions now allow to specify the to-be-applied changes directly in JSON. 
+* Various tiny code and documentation improvements. 
+
+
 ## Version 1.9.2
 
 * Testing code improvements.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ These tools are provided as-is and without warranty or support. They do not cons
 
 ______________________
 
-You can find additional information in the [Software AG TECHcommunity](https://tech.forums.softwareag.com/tag/Cumulocity-IoT). There is also a introductory article ([Getting started with the Cumulocity Python API](https://tech.forums.softwareag.com/t/getting-started-with-the-cumulocity-python-api/264700)) available.
+You can find additional information in the [Software AG TECHcommunity](https://tech.forums.softwareag.com/tag/Cumulocity-IoT). There is also an introductory article ([Getting started with the Cumulocity Python API](https://tech.forums.softwareag.com/t/getting-started-with-the-cumulocity-python-api/264700)) available.
 
 Contact us at [TECHcommunity](mailto:technologycommunity@softwareag.com?subject=Github/SoftwareAG) if you have any questions.
 

--- a/c8y_api/_base_api.py
+++ b/c8y_api/_base_api.py
@@ -188,7 +188,7 @@ class CumulocityRestApi:
             raise KeyError(f"No such object: {resource}")
         if 500 <= r.status_code <= 599:
             raise SyntaxError(f"Invalid POST request. Status: {r.status_code} Response:\n" + r.text)
-        if r.status_code not in (200, 201):
+        if r.status_code not in (200, 201, 204):
             raise ValueError(f"Unable to perform POST request. Status: {r.status_code} Response:\n" + r.text)
         if r.content:
             return r.json()
@@ -269,7 +269,7 @@ class CumulocityRestApi:
             raise KeyError(f"No such object: {resource}")
         if 500 <= r.status_code <= 599:
             raise SyntaxError(f"Invalid PUT request. Status: {r.status_code} Response:\n" + r.text)
-        if r.status_code != 200:
+        if r.status_code not in (200, 202, 204):
             raise ValueError(f"Unable to perform PUT request. Status: {r.status_code} Response:\n" + r.text)
         if r.content:
             return r.json()

--- a/c8y_api/_registry_api.py
+++ b/c8y_api/_registry_api.py
@@ -67,7 +67,7 @@ class CumulocityDeviceRegistry(CumulocityRestApi):
                 'ms' (milliseconds).
                 A reasonable value for this depends on application.
             pause (str):  How long to pause between request confirmation checks
-                This is a formmated string, see `timeout` parameter.
+                This is a formatted string, see `timeout` parameter.
 
         Returns:
             Credentials object holding the device credentials
@@ -119,7 +119,7 @@ class CumulocityDeviceRegistry(CumulocityRestApi):
                 'ms' (milliseconds).
                 A reasonable value for this depends on application.
             pause (str):  How long to pause between request confirmation checks
-                This is a formmated string, see `timeout` parameter.
+                This is a formatted string, see `timeout` parameter.
 
         Returns:
             Device-specific CumulocityAPI instance

--- a/c8y_api/app/__init__.py
+++ b/c8y_api/app/__init__.py
@@ -33,7 +33,7 @@ class _CumulocityAppBase(object):
         """Return a user-specific CumulocityApi instance.
 
         The instance will have user access, based on the Authorization header
-        provided in the headers dict. The instance will be build on demand,
+        provided in the headers dict. The instance will be built on demand,
         previously created instances are cached.
 
         Args:
@@ -100,10 +100,10 @@ class SimpleCumulocityApp(_CumulocityAppBase, CumulocityApi):
     """Application-like Cumulocity API.
 
     The SimpleCumulocityApp class is intended to be used as base within
-    a single-tenant micro service hosted on Cumulocity. It evaluates the
+    a single-tenant microservice hosted on Cumulocity. It evaluates the
     environment to the resolve the authentication information automatically.
 
-    Note: This class should be used in Cumulocity micro services using the
+    Note: This class should be used in Cumulocity microservices using the
     PER_TENANT authentication mode only. It will not function in environments
     using the MULTITENANT mode.
 
@@ -154,11 +154,11 @@ class MultiTenantCumulocityApp(_CumulocityAppBase):
     """Multi-tenant enabled Cumulocity application wrapper.
 
     The MultiTenantCumulocityApp class is intended to be used as base within
-    a multi-tenant micro service hosted on Cumulocity. It evaluates the
+    a multi-tenant microservice hosted on Cumulocity. It evaluates the
     environment to the resolve the bootstrap authentication information
     automatically.
 
-    Note: This class is intended to be used in Cumulocity micro services
+    Note: This class is intended to be used in Cumulocity microservices
     using the MULTITENANT authentication mode. It will not function in
     PER_TENANT environments.
 

--- a/c8y_api/model/_parser.py
+++ b/c8y_api/model/_parser.py
@@ -56,10 +56,11 @@ class SimpleObjectParser(object):
         If a field is present in both lists, it will be excluded.
 
         Args:
+            obj (object): the object to represent in JSON format.
             include:  an iterable of object fields to include or None if all
-                fields should be included
+                fields should be included.
             exclude:  an iterable of object fields to exclude or None of no
-                field should be excluded
+                field should be excluded.
 
         Returns:
             A JSON representation (nested dict) of the object.

--- a/c8y_api/model/alarms.py
+++ b/c8y_api/model/alarms.py
@@ -124,7 +124,7 @@ class Alarm(ComplexObject):
         """Convert the first occurrence time to a Python datetime object.
 
         Returns:
-            Standard Python datetime object for the first occurance time.
+            Standard Python datetime object for the first occurrence time.
         """
         return super()._to_datetime(self.first_occurrence_time)
 
@@ -205,7 +205,7 @@ class Alarm(ComplexObject):
         must be defined for this to function. This is always the case if
         the instance was built by the API.
 
-        See also functions Alarms.delete and Alarms.delete_by
+        See also functions `Alarms.delete` and `Alarms.delete_by`
         """
         self._assert_c8y()
         if not self.type:
@@ -371,11 +371,12 @@ class Alarms(CumulocityResource):
         """
         super()._update(Alarm.to_diff_json, *alarms)
 
-    def apply_to(self, alarm, *alarm_ids):
+    def apply_to(self, alarm: Alarm|dict, *alarm_ids: str):
         """Apply changes made to a single instance to other objects in the database.
 
         Args:
-            alarm (Alarm): Object serving as model for the update
+            alarm (Alarm|dict): Object serving as model for the update or
+                simply a dictionary representing the diff JSON.
             *alarm_ids (str): A collection of database IDS of alarms
         """
         super()._apply_to(Alarm.to_full_json, alarm, *alarm_ids)

--- a/c8y_api/model/binaries.py
+++ b/c8y_api/model/binaries.py
@@ -62,7 +62,7 @@ class Binary(ManagedObject):
         Raises:
             FileNotFoundError:  if the file refers to an invalid path.
 
-        See also function Binaries.create which doesn't parse the result.
+        See also function `Binaries.create` which doesn't parse the result.
         """
         self._assert_c8y()
         response_json = self.c8y.post_file(self._build_resource_path(), file=self.file,

--- a/c8y_api/model/events.py
+++ b/c8y_api/model/events.py
@@ -348,12 +348,13 @@ class Events(CumulocityResource):
         """
         super()._update(Event.to_diff_json, *events)
 
-    def apply_to(self, event: Event, *event_ids: str):
+    def apply_to(self, event: Event|dict, *event_ids: str):
         """Apply changes made to a single instance to other objects in the
         database.
 
         Args:
-            event (Event): Event used as model for the update
+            event (Event|dict): Event used as model for the update or simply
+                a dictionary representing the diff JSON.
             *event_ids (str):  Collection of ID of the events to update
         """
         super()._apply_to(Event.to_full_json, event, *event_ids)

--- a/c8y_api/model/inventory.py
+++ b/c8y_api/model/inventory.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, Generator, List
 
 from c8y_api.model._base import CumulocityResource
@@ -42,8 +43,19 @@ class Inventory(CumulocityResource):
         managed_object.c8y = self.c8y  # inject c8y connection into instance
         return managed_object
 
-    def get_all(self, type: str = None, fragment: str = None, name: str = None, owner: str = None,  # noqa (type)
-                limit: int = None, page_size: int = 1000):
+    def get_all(
+            self,
+            expression: str = None,
+            type: str = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str | int] = None,
+            limit: int = None,
+            page_size: int = 1000
+    ) -> List[ManagedObject]:
         """ Query the database for managed objects and return the results
         as list.
 
@@ -53,10 +65,29 @@ class Inventory(CumulocityResource):
         Returns:
             List of ManagedObject instances
         """
-        return list(self.select(type=type, fragment=fragment, name=name, owner=owner, limit=limit, page_size=page_size))
+        return list(self.select(
+            expression=expression,
+            type=type,
+            fragment=fragment,
+            name=name,
+            owner=owner,
+            query=query,
+            text=text,
+            ids=ids,
+            limit=limit,
+            page_size=page_size))
 
-    def get_count(self, type: str = None, fragment: str = None, name: str = None,
-                  owner: str = None, query: str = None) -> int:  # noqa (type)
+    def get_count(
+            self,
+            expression: str = None,
+            type: str = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str | int] = None
+    ) -> int:
         """Calculate the number of potential results of a database query.
 
         This function uses the same parameters as the `select` function.
@@ -64,13 +95,32 @@ class Inventory(CumulocityResource):
         Returns:
             Number of potential results
         """
-        base_query = self._prepare_query(type=type, fragment=fragment, name=name,
-                                         owner=owner, query=query, page_size=1)
+        base_query = self._prepare_query(
+            expression=expression,
+            type=type,
+            fragment=fragment,
+            name=name,
+            owner=owner,
+            query=query,
+            text=text,
+            ids=ids,
+            page_size=1)
         return self._get_count(base_query)
 
-    def select(self, type: str = None, fragment: str = None, name: str = None, owner: str = None,  # noqa (type)
-               query: str = None, limit: int = None,
-               page_size: int = 1000, page_number: int = None) -> Generator[ManagedObject]:
+    def select(
+            self,
+            expression: str = None,
+            type: str = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str|int] = None,
+            limit: int = None,
+            page_size: int = 1000,
+            page_number: int = None
+    ) -> Generator[ManagedObject]:
         """ Query the database for managed objects and iterate over the
         results.
 
@@ -82,6 +132,9 @@ class Inventory(CumulocityResource):
         combined (within reason).
 
         Args:
+            expression (str):  Arbitrary filter expression which will be
+                passed to Cumulocity without change; all other filters
+                are ignored if this is provided
             type (str):  Managed object type
             fragment (str):  Name of a present custom/standard fragment
             name (str):  Name of the managed object
@@ -91,6 +144,8 @@ class Inventory(CumulocityResource):
             owner (str):  Username of the object owner
             query (str):  Complex query to execute; all other filters are
                 ignored if such a custom query is provided
+            text (str): Text value of any object property.
+            ids (List[str|int]): Specific object ID to select.
             limit (int): Limit the number of results to this number.
             page_size (int): Define the number of events which are read (and
                 parsed in one chunk). This is a performance related setting.
@@ -100,22 +155,55 @@ class Inventory(CumulocityResource):
         Returns:
             Generator for ManagedObject instances
         """
-        return self._select(ManagedObject.from_json, type=type, fragment=fragment, name=name, owner=owner,
-                            query=None, limit=limit, page_size=page_size, page_number=page_number)
+        return self._select(
+            ManagedObject.from_json,
+            expression=expression,
+            type=type,
+            fragment=fragment,
+            name=name,
+            owner=owner,
+            query=query,
+            text=text,
+            ids=ids,
+            limit=limit,
+            page_size=page_size,
+            page_number=page_number)
 
-    def _prepare_query(self, type: str = None, fragment: str = None, name: str = None,  # noqa
-                owner: str = None, query: str = None, page_size: int = 1000) -> str:
+    @classmethod
+    def _prepare_query_param(cls, query, filters):
+        """Potentially extend a query parameter with additional filters.
+
+        If there are no additional filters, the query parameter is not
+        touched. Otherwise, a complete query is prepared which consists of
+        the original query plus all additional filters.
+        """
+        if not filters:
+            return query
+        add_filters = ' and '.join(filters)
+        if not query:
+            return add_filters
+        return query + ' $filter=(' + add_filters + ')'
+
+    def _prepare_query(
+            self,
+            expression: str = None,
+            type: str = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            **kwargs
+    ) -> str:
         """The inventory API features a query API that needs some additional
         preparations before we can actually invoke the queries."""
-        query_filters = []
-
+        if expression:
+            return self._build_base_query(expression=expression)
         # if there is no custom query, we check whether standard filters need to
         # be translated into a query
         if not query and name:
-
             # A name filter can only be expressed as a query, which then
             # triggers "query mode" (all filters are translated into a query)
-            query_filters.append(f"name eq '{_QueryUtil.encode_odata_query_value(name)}'")
+            query_filters = [f"name eq '{_QueryUtil.encode_odata_query_value(name)}'"]
 
             if type:
                 query_filters.append(f"type eq '{type}'")
@@ -123,22 +211,18 @@ class Inventory(CumulocityResource):
                 query_filters.append(f"owner eq '{owner}'")
             if fragment:
                 query_filters.append(f"has({fragment})")
-            if len(query_filters) == 1:
-                query = query_filters[0]
-            else:
-                query = '$filter=(' + ' and '.join(query_filters) + ')'
+            query = ' and '.join(query_filters)
 
         if query:
-            return self._build_base_query(query=query, page_size=page_size)
-        return self._build_base_query(type=type, fragment=fragment, owner=owner, page_size=page_size)
+            # all parameters except page_size (which is not a filter) are ignored
+            return self._build_base_query(query=query, page_size=kwargs.get('page_size', None))
+        return self._build_base_query(type=type, fragment=fragment, owner=owner, **kwargs)
 
-    def _select(self, jsonyfy_func, type: str = None, fragment: str = None, name: str = None,  # noqa
-                owner: str = None, query: str = None, limit: int = None,
-                page_size: int = 1000, page_number: int = None) -> Generator[Any]:
-        base_query = self._prepare_query(type=type, fragment=fragment, name=name,
-                                         owner=owner, query=query, page_size=page_size)
-        return  super()._iterate(base_query, page_number, limit, jsonyfy_func)
-
+    def _select(self, jsonify_func, **kwargs) -> Generator[Any]:
+        """Generic select function to be used by derived classes as well."""
+        page_number = kwargs.pop('page_number', None)
+        limit = kwargs.pop('limit', None)
+        return super()._iterate(self._prepare_query(**kwargs), page_number, limit, jsonify_func)
 
     def create(self, *objects: ManagedObject):
         """Create managed objects within the database.
@@ -154,11 +238,11 @@ class Inventory(CumulocityResource):
         Args:
            *objects (ManagedObject): collection of ManagedObject instances
 
-        See also function ManagedObject.update which parses the result.
+        See also function `ManagedObject.update` which parses the result.
         """
         super()._update(ManagedObject.to_diff_json, *objects)
 
-    def apply_to(self, object_model: ManagedObject, *object_ids):
+    def apply_to(self, object_model: ManagedObject | dict, *object_ids):
         """Apply a change to multiple already existing objects.
 
         Applies the details of a model object to a set of already existing
@@ -167,8 +251,9 @@ class Inventory(CumulocityResource):
         Note: This will take the full details, not just the updates.
 
         Args:
-            object_model (ManagedObject): ManagedObject instance holding
-                the change structure (e.g. a specific fragment)
+            object_model (ManagedObject|dict): ManagedObject instance holding
+                the change structure (e.g. a specific fragment) or simply a
+                dictionary representing the diff JSON.
             *object_ids (str): a collection of ID of already existing
                 managed objects within the database
         """
@@ -211,6 +296,7 @@ class Inventory(CumulocityResource):
         """
         result_json = self.c8y.get(self.build_object_path(mo_id) + '/' + ManagedObject.Resource.SUPPORTED_SERIES)
         return result_json[ManagedObject.Fragment.SUPPORTED_SERIES]
+
 
 class DeviceInventory(Inventory):
     """Provides access to the Device Inventory API.
@@ -255,9 +341,27 @@ class DeviceInventory(Inventory):
         device.c8y = self.c8y
         return device
 
-    def select(self, type: str = None, name: str = None, owner: str = None,  # noqa (type, args)
-               query: str = None, limit: int = None,
-               page_size: int = 100, page_number: int = None) -> Generator[Device]:
+    @classmethod
+    def _prepare_device_query_param(cls, query: str) -> str:
+        if query:
+            # insert after opening bracket or at the beginning
+            insert_at = query.find('filter=', ) + 1
+            query = query[:insert_at] + "has(c8y_IsDevice) and " + query[insert_at:]
+        return query
+
+    def select(  # noqa (order)
+            self,
+            expression: str = None,
+            type: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str | int] = None,
+            limit: int = None,
+            page_size: int = 100,
+            page_number: int = None
+    ) -> Generator[Device]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Query the database for devices and iterate over the results.
 
@@ -272,6 +376,9 @@ class DeviceInventory(Inventory):
         `c8y_IsDevice` fragment is automatically filtered.
 
         Args:
+            expression (str):  Arbitrary filter expression which will be
+                passed to Cumulocity without change; all other filters
+                are ignored if this is provided
             type (str):  Device type
             name (str):  Name of the device
                 Note: The Cumulocity REST API does not support filtering for
@@ -280,6 +387,8 @@ class DeviceInventory(Inventory):
             owner (str):  Username of the object owner
             query (str):  Complex query to execute; all other filters are
                 ignored if such a custom query is provided
+            text (str): Text value of any object property.
+            ids (List[str|int]): Specific object ID to select.
             limit (int): Limit the number of results to this number.
             page_size (int): Define the number of events which are read (and
                 parsed in one chunk). This is a performance related setting.
@@ -289,11 +398,32 @@ class DeviceInventory(Inventory):
         Returns:
             Generator for Device objects
         """
-        return self._select(ManagedObject.from_json, type=type, fragment='c8y_IsDevice', name=name, owner=owner,
-                            query=query, limit=limit, page_size=page_size, page_number=page_number)
+        return super()._select(
+            Device.from_json,
+            type=type,
+            fragment='c8y_IsDevice',
+            name=name,
+            owner=owner,
+            query=self._prepare_device_query_param(query),
+            text=text,
+            ids=ids,
+            limit=limit,
+            page_size=page_size,
+            page_number=page_number)
 
-    def get_all(self, type: str = None, name: str = None, owner: str = None,   # noqa (type, parameters)
-                limit: int = None, page_size: int = 100, page_number: int = None) -> List[Device]:
+    def get_all(  # noqa (changed signature)
+            self,
+            expression: str = None,
+            type: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str | int] = None,
+            limit: int = None,
+            page_size: int = 100,
+            page_number: int = None
+    ) -> List[Device]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Query the database for devices and return the results as list.
 
@@ -303,10 +433,27 @@ class DeviceInventory(Inventory):
         Returns:
             List of Device objects
         """
-        return list(self.select(type=type, name=name, owner=owner, limit=limit,
-                                page_size=page_size, page_number=page_number))
+        return list(self.select(
+            expression=expression,
+            type=type,
+            name=name,
+            owner=owner,
+            query=self._prepare_device_query_param(query),
+            text=text,
+            ids=ids,
+            limit=limit,
+            page_size=page_size,
+            page_number=page_number))
 
-    def get_count(self, type: str = None, name: str = None, owner: str = None) -> int:  # noqa
+    def get_count(  # noqa (changed signature)
+            self,
+            type: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str | int] = None
+    ) -> int:
         # pylint: disable=arguments-differ, arguments-renamed
         """Calculate the number of potential results of a database query.
 
@@ -315,12 +462,20 @@ class DeviceInventory(Inventory):
         Returns:
             Number of potential results
         """
-        return self._get_count(super()._prepare_query(type=type, name=name, owner=owner, page_size=1))
+        return self._get_count(super()._prepare_query(
+            type=type,
+            fragment='c8y_IsDevice',
+            name=name,
+            owner=owner,
+            query=self._prepare_device_query_param(query),
+            text=text,
+            ids=ids,
+            page_size=1))
 
     def delete(self, *devices: Device):
         """ Delete one or more devices and the corresponding within the database.
 
-        The objects can be specified as instances of an database object
+        The objects can be specified as instances of a database object
         (then, the id field needs to be defined) or simply as ID (integers
         or strings).
 
@@ -362,42 +517,60 @@ class DeviceGroupInventory(Inventory):
         group.c8y = self.c8y
         return group
 
-    def _prepare_query(self, type: str, parent: str | int = None, fragment: str = None,  # noqa
-               name: str = None, owner: str = None, query: str = None, page_size: int = 100) -> str:
+    def _prepare_device_group_query(
+            self,
+            type: str,
+            parent: str | int = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            **kwargs
+    ) -> str:
         # pylint: disable=arguments-differ, arguments-renamed
+
         query_filters = []
+        # Both name and parent filters can only be expressed as a query,
+        # which then triggers "query mode"
+        if name:
+            query_filters.append(f"name eq '{_QueryUtil.encode_odata_query_value(name)}'")
+        if parent:
+            query_filters.append(f"bygroupid({parent})")
+            type = DeviceGroup.CHILD_TYPE  # noqa
 
-        # if there is no custom query, we check whether standard filters need to
-        # be translated into a query
-        if not query:
+        # if any query was defined, all filters must be put into the query
+        if query_filters:
+            if type:
+                query_filters.append(f"type eq '{type}'")
+            if owner:
+                query_filters.append(f"owner eq '{owner}'")
+            if fragment:
+                query_filters.append(f"has({fragment}")
 
-            # Both name and parent filters can only be expressed as a query,
-            # which then triggers "query mode"
-            if name:
-                query_filters.append(f"name eq '{_QueryUtil.encode_odata_query_value(name)}'")
-            if parent:
-                query_filters.append(f"bygroupid({parent})")
-                type = DeviceGroup.CHILD_TYPE  # noqa
-
-            # if any query was defined, all filters must be put into the query
-            if query_filters:
-                if type:
-                    query_filters.append(f"type eq '{type}'")
-                if owner:
-                    query_filters.append(f"owner eq '{owner}'")
-                if fragment:
-                    query_filters.append(f"has({fragment}")
-                query = '$filter=' + ' and '.join(query_filters)
+        if query_filters:
+            query = self._prepare_query_param(query, query_filters)
 
         if query:
+            page_size = kwargs.get('page_size', None)
             return self._build_base_query(query=query, page_size=page_size)
 
-        return self._build_base_query(type=type, fragment=fragment, owner=owner, page_size=page_size)
+        return self._build_base_query(type=type, fragment=fragment, owner=owner, **kwargs)
 
-
-    def select(self, type: str = DeviceGroup.ROOT_TYPE, parent: str | int = None, fragment: str = None,  # noqa
-               name: str = None, owner: str = None, query: str = None,
-               page_size: int = 100, page_number: int = None) -> Generator[DeviceGroup]:
+    def select(  # noqa (changed signature)
+            self,
+            expression: str = None,
+            type: str = DeviceGroup.ROOT_TYPE,
+            parent: str|int = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str|int] = None,
+            limit: int = None,
+            page_size: int = 100,
+            page_number: int = None
+    ) -> Generator[DeviceGroup]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Select device groups by various parameters.
 
@@ -405,10 +578,13 @@ class DeviceGroupInventory(Inventory):
         parsed and returned one by one.
 
         The type of all DeviceGroup objects is fixed 'c8y_DeviceGroup',
-        'c8y_DeviceSubGroup' if searching by `parent` respectively. Hence
+        'c8y_DeviceSubGroup' if searching by `parent` respectively. Hence,
         manual filtering by type is not supported.
 
         Args:
+            expression (str):  Arbitrary filter expression which will be
+                passed to Cumulocity without change; all other filters
+                are ignored if this is provided
             type (bool):  Filter for root or child groups respectively.
                 Note: If set to None, no type filter will be applied which
                 will match all kinds of managed objects. If you want to
@@ -426,6 +602,9 @@ class DeviceGroupInventory(Inventory):
             owner (str): Username of the group owner
             query (str):  Complex query to execute; all other filters are
                 ignored if such a custom query is provided
+            text (str): Text value of any object property.
+            ids (List[str|int]): Specific object ID to select
+            limit (int): Limit the number of results to this number.
             page_size (int): Define the number of events which are read (and
                 parsed in one chunk). This is a performance related setting.
             page_number (int): Pull a specific page; this effectively disables
@@ -434,12 +613,31 @@ class DeviceGroupInventory(Inventory):
         Returns:
             Generator of DeviceGroup instances
         """
-        base_query = self._prepare_query(type=type, parent=parent, fragment=fragment,
-                                         name=name, owner=owner, query=query, page_size=page_size)
-        return super()._iterate(base_query, page_number, limit=9999, parse_func=DeviceGroup.from_json)
+        base_query = self._prepare_device_group_query(
+            expression=expression,
+            type=type,
+            parent=parent,
+            fragment=fragment,
+            name=name,
+            owner=owner,
+            query=query,
+            text=text,
+            ids=ids,
+            page_size=page_size)
+        return super()._iterate(base_query, page_number, limit=limit, parse_func=DeviceGroup.from_json)
 
-    def get_count(self, type: str = DeviceGroup.ROOT_TYPE, parent: str | int = None, fragment: str = None,
-               name: str = None, owner: str = None, query: str = None) -> int:
+    def get_count(  # noqa (changed signature)
+            self,
+            expression: str = None,
+            type: str = DeviceGroup.ROOT_TYPE,
+            parent: str|int = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str|int] = None,
+    ) -> int:
         # pylint: disable=arguments-differ, arguments-renamed
         """Calculate the number of potential results of a database query.
 
@@ -448,12 +646,33 @@ class DeviceGroupInventory(Inventory):
         Returns:
             Number of potential results
         """
-        base_query = self._prepare_query(type=type, parent=parent, fragment=fragment,
-                                         name=name, owner=owner, query=query, page_size=1)
+        base_query = self._prepare_device_group_query(
+            expression=expression,
+            type=type,
+            parent=parent,
+            fragment=fragment,
+            name=name,
+            owner=owner,
+            query=query,
+            text=text,
+            ids=ids,
+            page_size=1)
         return self._get_count(base_query)
 
-    def get_all(self, type: str = DeviceGroup.ROOT_TYPE, parent: str | int = None, fragment: str = None, # noqa
-                name: str = None, owner: str = None, page_size: int = 100, page_number: int = None):  # noqa
+    def get_all(  # noqa (changed signature)
+            self,
+            expression: str = None,
+            type: str = DeviceGroup.ROOT_TYPE,
+            parent: str | int = None,
+            fragment: str = None,
+            name: str = None,
+            owner: str = None,
+            query: str = None,
+            text: str = None,
+            ids: List[str|int] = None,
+            page_size: int = 100,
+            page_number: int = None
+    ) -> List[DeviceGroup]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Select managed objects by various parameters.
 
@@ -463,8 +682,18 @@ class DeviceGroupInventory(Inventory):
         Returns:
             List of DeviceGroup instances.
         """
-        return list(self.select(type=type, parent=parent, fragment=fragment, name=name,
-                                page_size=page_size, page_number=page_number))
+        return list(self.select(
+            expression=expression,
+            type=type,
+            parent=parent,
+            fragment=fragment,
+            name=name,
+            owner=owner,
+            query=query,
+            text=text,
+            ids=ids,
+            page_size=page_size,
+            page_number=page_number))
 
     def create(self, *groups):
         """Batch create a collection of groups and entire group trees.
@@ -499,11 +728,11 @@ class DeviceGroupInventory(Inventory):
         refs = {'references': [ManagedObjectUtil.build_managed_object_reference(i) for i in child_ids]}
         self.c8y.delete(self.build_object_path(root_id) + '/childAssets', json=refs)
 
-    def delete(self, *groups: DeviceGroup|str):
+    def delete(self, *groups: DeviceGroup | str):
         """Delete one or more single device groups within the database.
 
         The child groups (if there are any) are left dangling. This is
-        equivalent to using the `cascase=false` parameter in the
+        equivalent to using the `cascade=false` parameter in the
         Cumulocity REST API.
 
         Args:
@@ -511,7 +740,7 @@ class DeviceGroupInventory(Inventory):
         """
         self._delete(False, *groups)
 
-    def delete_trees(self, *groups: DeviceGroup|str):
+    def delete_trees(self, *groups: DeviceGroup | str):
         """Delete one or more device groups trees within the database.
 
         This is equivalent to using the `cascade=true` parameter in the
@@ -522,7 +751,7 @@ class DeviceGroupInventory(Inventory):
         """
         self._delete(False, *groups)
 
-    def _delete(self, cascade: bool, *objects: DeviceGroup|str):
+    def _delete(self, cascade: bool, *objects: DeviceGroup | str):
         try:
             object_ids = [o.id for o in objects]  # noqa (id)
         except AttributeError:

--- a/c8y_api/model/managedobjects.py
+++ b/c8y_api/model/managedobjects.py
@@ -213,7 +213,7 @@ class ManagedObject(ComplexObject):
         mo.add_fragment('c8y_CustomValue', value=12, uom='units')
 
     Note: This does not work if a fragment is actually a field, not a
-    structure own it's own. A direct assignment to such a value fragment,
+    structure own its own. A direct assignment to such a value fragment,
     like
 
         mo.c8y_CustomReferences = [1, 2, 3]
@@ -374,7 +374,7 @@ class ManagedObject(ComplexObject):
             object within the database. This instance can be used to get
             at the ID of the new managed object.
 
-        See also function Inventory.create which doesn't parse the result.
+        See also function `Inventory.create` which doesn't parse the result.
         """
         return self._create()
 
@@ -385,7 +385,7 @@ class ManagedObject(ComplexObject):
             A fresh ManagedObject instance representing the updated
             object within the database.
 
-        See also function Inventory.update which doesn't parse the result.
+        See also function `Inventory.update` which doesn't parse the result.
         """
         return self._update()
 
@@ -397,10 +397,10 @@ class ManagedObject(ComplexObject):
         Args:
             other_id (str|int):  Database ID of the event to update.
         Returns:
-            A fresh ManagedObject instance representing the updated
+            A fresh `ManagedObject` instance representing the updated
             object within the database.
 
-        See also function Inventory.apply_to which doesn't parse the result.
+        See also function `Inventory.apply_to` which doesn't parse the result.
         """
         self._assert_c8y()
         # put diff json to another object (by ID)
@@ -620,7 +620,7 @@ class DeviceGroup(ManagedObject):
     def __init__(self, c8y=None, root: bool = False, name: str = None, owner: str = None, **kwargs):
         """ Build a new DeviceGroup object.
 
-        A type of a device group will always be either `c8y_DeviceGroup`
+        The type of a device group will always be either `c8y_DeviceGroup`
         or `c8y_DeviceSubGroup` (depending on it's level). This is handled
         by the API.
 
@@ -696,7 +696,7 @@ class DeviceGroup(ManagedObject):
             object within the database. This instance can be used to get at
             the ID of the new object.
 
-        See also function DeviceGroupInventory.create which doesn't parse
+        See also function `DeviceGroupInventory.create` which doesn't parse
         the result.
         """
         return super()._create()

--- a/c8y_api/model/measurements.py
+++ b/c8y_api/model/measurements.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import dataclasses
-import datetime
+from datetime import datetime, timedelta
 from typing import Type, List, Generator, Sequence
 from urllib.parse import urlencode
 
@@ -122,7 +122,7 @@ class Measurement(ComplexObject):
     # _accept
     # _not_updatable
 
-    def __init__(self, c8y=None, type=None, source=None, time=None, **kwargs):  # noqa (type)
+    def __init__(self, c8y=None, type=None, source=None, time: str|datetime = None, **kwargs):  # noqa (type)
         """ Create a new Measurement object.
 
         Args:
@@ -132,7 +132,7 @@ class Measurement(ComplexObject):
             source (str)  Device ID which this measurement is for
             time(str|datetime):  Datetime string or Python datetime object. A
                 given datetime string needs to be in standard ISO format incl.
-                timezone: YYYY-MM-DD'T'HH:MM:SS.SSSZ as it is retured by the
+                timezone: YYYY-MM-DD'T'HH:MM:SS.SSSZ as it is returned by the
                 Cumulocity REST API. A given datetime object needs to be
                 timezone aware. For manual construction it is recommended to
                 specify a datetime object as the formatting of a timestring
@@ -149,7 +149,7 @@ class Measurement(ComplexObject):
         # The time can either be set as string (e.g. when read from JSON) or
         # as a datetime object. It will be converted to string immediately
         # as there is no scenario where a manually created object won't be
-        # written to Cumulocity anyways
+        # written to Cumulocity anyway
         self.time = _DateUtil.ensure_timestring(time)
 
     @classmethod
@@ -160,7 +160,7 @@ class Measurement(ComplexObject):
         Cumulocity REST API.
 
         Args:
-            measurement_json (dict)  JSON object (nested dictionary)
+            json (dict)  JSON object (nested dictionary)
                 representing a measurement within Cumulocity
 
         Returns:
@@ -216,7 +216,7 @@ class Measurement(ComplexObject):
 
     def update(self) -> Measurement:
         """Not implemented for Measurements."""
-        raise NotImplementedError('Measurements cannot be updated within Cumuylocity.')
+        raise NotImplementedError('Measurements cannot be updated within Cumulocity.')
 
     def delete(self):
         """Delete the Measurement within the database."""
@@ -249,7 +249,7 @@ class Series(dict):
     @property
     def truncated(self):
         """Whether the result was truncated
-        (i.e. the query returned more that 5000 values)."""
+        (i.e. the query returned more than 5000 values)."""
         return self['truncated']
 
     @property
@@ -267,7 +267,7 @@ class Series(dict):
                 be a tuple. If omitted, all available series are collected.
             value (str):  Which value (min/max) to collect. If omitted, both
                 values will be collected, grouped as 2-tuples.
-            timestamp (bool|str):  Whether each element in the result list will
+            timestamps (bool|str):  Whether each element in the result list will
                 be prepended with the corresponding timestamp. If True, the
                 timestamp string will be included; Use 'datetime' or 'epoch' to
                 parse the timestamp string.
@@ -286,9 +286,9 @@ class Series(dict):
         def parse_timestamp(t):
             """Parse timestamps."""
             if timestamps == 'datetime':
-                return datetime.datetime.fromisoformat(t)
+                return datetime.fromisoformat(t)
             if timestamps == 'epoch':
-                return datetime.datetime.fromisoformat(t).timestamp()
+                return datetime.fromisoformat(t).timestamp()
             return t
 
         # use all series if no series provided
@@ -401,10 +401,22 @@ class Measurements(CumulocityResource):
         measurement.c8y = self.c8y  # inject c8y connection into instance
         return measurement
 
-    def select(self, type=None, source=None,  # noqa (type)
-               fragment=None, value=None, series=None,
-               before=None, after=None, min_age=None, max_age=None, reverse=False,
-               limit=None, page_size: int = 1000, page_number: int = None) -> Generator[Measurement]:
+    def select(
+            self,
+            type: str = None,
+            source: str | int = None,
+            fragment: str = None,
+            value: str = None,
+            series: str = None,
+            before: str | datetime = None,
+            after: str | datetime = None,
+            min_age: timedelta = None,
+            max_age: timedelta = None,
+            reverse: bool = None,
+            limit: int = None,
+            page_size: int = 1000,
+            page_number: int = None
+    ) -> Generator[Measurement]:
         """ Query the database for measurements and iterate over the results.
 
         This function is implemented in a lazy fashion - results will only be
@@ -416,9 +428,9 @@ class Measurements(CumulocityResource):
 
         Args:
             type (str):  Alarm type
-            source (str):  Database ID of a source device
+            source (str|int):  Database ID of a source device
             fragment (str):  Name of a present custom/standard fragment
-            value (str):  Name/type of a present value fragment
+            value (str):  Type/Name of a present value fragment
             series (str):  Name of a present series within a value fragment
             before (datetime|str):  Datetime object or ISO date/time string.
                 Only measurements assigned to a time before this date are
@@ -448,10 +460,22 @@ class Measurements(CumulocityResource):
                                             reverse=reverse, page_size=page_size)
         return super()._iterate(base_query, page_number, limit, Measurement.from_json)
 
-    def get_all(self, type=None, source=None,  # noqa (type)
-                fragment=None,  value=None, series=None,
-                before=None, after=None, min_age=None, max_age=None, reverse=False,
-                limit=None, page_size=1000, page_number: int = None) -> List[Measurement]:
+    def get_all(
+            self,
+            type: str = None,
+            source: str | int = None,
+            fragment: str = None,
+            value: str = None,
+            series: str = None,
+            before: str | datetime = None,
+            after: str | datetime = None,
+            min_age: timedelta = None,
+            max_age: timedelta = None,
+            reverse: bool = None,
+            limit: int = None,
+            page_size: int = 1000,
+            page_number: int = None
+    ) -> List[Measurement]:
         """ Query the database for measurements and return the results
         as list.
 
@@ -461,13 +485,31 @@ class Measurements(CumulocityResource):
         Returns:
             List of matching Measurement objects
         """
-        return list(self.select(type=type, source=source,
-                                fragment=fragment, value=value, series=series,
-                                before=before, after=after, min_age=min_age, max_age=max_age,
-                                reverse=reverse, limit=limit, page_size=page_size, page_number=page_number))
+        return list(self.select(
+            type=type,
+            source=source,
+            fragment=fragment,
+            value=value,
+            series=series,
+            before=before,
+            after=after,
+            min_age=min_age,
+            max_age=max_age,
+            reverse=reverse,
+            limit=limit,
+            page_size=page_size,
+            page_number=page_number))
 
-    def get_last(self, type=None, source=None, fragment=None, value=None, series=None,  # noqa (type)
-                 before=None, min_age=None) -> Measurement:
+    def get_last(
+            self,
+            type: str = None,
+            source: str | int = None,
+            fragment: str = None,
+            value: str = None,
+            series: str = None,
+            before: str | datetime = None,
+            min_age: timedelta = None
+    ) -> Measurement:
         """ Query the database and return the last matching measurement.
 
         This function is a special variant of the select function. Only
@@ -481,15 +523,31 @@ class Measurements(CumulocityResource):
         after = None
         if not before and not min_age:
             after = '1970-01-01'
-        base_query = self._build_base_query(type=type, source=source,
-                                            fragment=fragment, value=value, series=series, after=after,
-                                            before=before, min_age=min_age, reverse=True, page_size=1)
-        m = Measurement.from_json(self._get_page(base_query, "1")[0])
+        base_query = self._build_base_query(
+            type=type,
+            source=source,
+            fragment=fragment,
+            value=value,
+            series=series,
+            after=after,
+            before=before,
+            min_age=min_age,
+            reverse=True,
+            page_size=1)
+        m = Measurement.from_json(self._get_page(base_query, page_number=1)[0])
         m.c8y = self.c8y  # inject c8y connection into instance
         return m
 
-    def get_series(self, source: str = None, aggregation: str = None, series: str | Sequence[str] = None,
-                   before=None, after=None, min_age=None, max_age=None, reverse=False) -> Series:
+    def get_series(
+            self,
+            source: str = None,
+            aggregation: str = None,
+            series: str | Sequence[str] = None,
+            before: str | datetime = None,
+            after: str | datetime = None,
+            min_age: timedelta = None,
+            max_age: timedelta = None,
+            reverse=False) -> Series:
         """Query the database for a list of series and their values.
 
         Args:
@@ -515,9 +573,15 @@ class Measurements(CumulocityResource):
 
         See also: https://cumulocity.com/api/core/#operation/getMeasurementSeriesResource
         """
-        params = self._prepare_query_params(source=source, aggregationType=aggregation,
-                                            before=before, after=after, min_age=min_age, max_age=max_age,
-                                            reverse=reverse)
+        params = self._prepare_query_params(
+            source=source,
+            # this is a non-mapped parameter
+            aggregationType=aggregation,
+            before=before,
+            after=after,
+            min_age=min_age,
+            max_age=max_age,
+            reverse=reverse)
         # The 'series' parameter has to be added manually; because it
         # may be a list and because 'series' is by default converted to
         # the 'valueFragmentSeries' parameter
@@ -529,9 +593,18 @@ class Measurements(CumulocityResource):
         series_json = self.c8y.get(url)
         return Series(series_json)
 
-    def delete_by(self, type=None, source=None,  # noqa (type)
-                fragment=None, value=None, series=None,
-                before=None, after=None, min_age=None, max_age=None):
+    def delete_by(
+            self,
+            type: str = None,
+            source: str | int = None,
+            fragment: str = None,
+            value: str = None,
+            series: str = None,
+            before: str | datetime = None,
+            after: str | datetime = None,
+            min_age: timedelta = None,
+            max_age: timedelta = None,
+        ):
         """ Query the database and delete matching measurements.
 
         All parameters are considered to be filters, limiting the result set
@@ -540,12 +613,17 @@ class Measurements(CumulocityResource):
 
         Args: See 'select' function
         """
-        base_query = self._build_base_query(type=type, source=source,
-                                            fragment=fragment, value=value, series=series,
-                                            before=before, after=after, min_age=min_age, max_age=max_age)
-        # remove &page_number= from the end
-        query = base_query[:base_query.rindex('&')]
-        self.c8y.delete(query)
+        base_query = self._build_base_query(
+            type=type,
+            source=source,
+            fragment=fragment,
+            value=value,
+            series=series,
+            before=before,
+            after=after,
+            min_age=min_age,
+            ax_age=max_age)
+        self.c8y.delete(base_query)
 
     # delete function is defined in super class
 

--- a/c8y_api/model/notification2.py
+++ b/c8y_api/model/notification2.py
@@ -116,7 +116,7 @@ class Subscription(SimpleObject):
             A fresh Subscription instance representing the created
             subscription within the database.
 
-        See also function Subscriptions.create which doesn't parse the result.
+        See also function `Subscriptions.create` which doesn't parse the result.
         """
         return self._create()
 

--- a/c8y_api/model/operations.py
+++ b/c8y_api/model/operations.py
@@ -175,10 +175,10 @@ class Operations(CumulocityResource):
             bulk_id (str): The bulk operation ID that this object belongs to
             fragment (str):  Name of a present custom/standard fragment
             before (datetime|str):  Datetime object or ISO date/time string.
-                Only operaton assigned to a time before this date are
+                Only operations assigned to a time before this date are
                 returned.
             after (datetime|str):  Datetime object or ISO date/time string.
-                Only operation assigned to a time after this date are
+                Only operations assigned to a time after this date are
                 returned.
             min_age (timedelta):  Timedelta object. Only operation of
                 at least this age are returned.
@@ -240,7 +240,7 @@ class Operations(CumulocityResource):
         base_query = self._build_base_query(agent_id=agent_id, device_id=device_id, status=status,
                                             bulk_id=bulk_id, fragment=fragment, after=after,
                                             before=before, min_age=min_age, reverse=True, page_size=1)
-        m = Operation.from_json(self._get_page(base_query, "1")[0])
+        m = Operation.from_json(self._get_page(base_query, 1)[0])
         m.c8y = self.c8y  # inject c8y connection into instance
         return m
 
@@ -261,11 +261,11 @@ class Operations(CumulocityResource):
             bulk_id (str): The bulk operation ID that this object belongs to
             fragment (str):  Name of a present custom/standard fragment
             before (datetime|str):  Datetime object or ISO date/time string.
-                Only operaton assigned to a time before this date are
-                returned.
+                Only operations assigned to a time before this date are
+                selected.
             after (datetime|str):  Datetime object or ISO date/time string.
                 Only operation assigned to a time after this date are
-                returned.
+                selected.
             min_age (timedelta):  Timedelta object. Only operation of
                 at least this age are returned.
             max_age (timedelta):  Timedelta object. Only operations with

--- a/c8y_api/model/tenant_options.py
+++ b/c8y_api/model/tenant_options.py
@@ -82,7 +82,7 @@ class TenantOption(SimpleObject):
             A fresh TenantOption instance representing the created
             option within the database.
 
-        See also function TenantOptions.create which doesn't parse the result.
+        See also function `TenantOptions.create` which doesn't parse the result.
         """
         return super()._create()
 
@@ -93,14 +93,14 @@ class TenantOption(SimpleObject):
             A fresh TenantOption instance representing the updated
             object within the database.
 
-        See also function TenantOptions.update which doesn't parse the result.
+        See also function `TenantOptions.update` which doesn't parse the result.
         """
         return super()._update()
 
     def delete(self) -> None:
         """Delete the option within the database.
 
-        See also function TenantOptions.delete to delete multiple objects.
+        See also function `TenantOptions.delete` to delete multiple objects.
         """
         super()._delete()
 
@@ -225,7 +225,7 @@ class TenantOptions(CumulocityResource):
         return self.c8y.get(resource=self.build_object_path(category, key))['value']
 
     def set_value(self, category: str, key: str, value: str):
-        """ Create a option within the database.
+        """ Create an option within the database.
 
         This is a shortcut function to avoid unnecessary instantiation of
         the TenantOption class.

--- a/c8y_tk/notification2/listener.py
+++ b/c8y_tk/notification2/listener.py
@@ -160,7 +160,7 @@ class AsyncListener(object):
     async def receive(self):
         """Read a message.
 
-        This will wait for a inbound message on the communication channel
+        This will wait for an inbound message on the communication channel
         and return it (raw).
 
         Returns:
@@ -280,7 +280,7 @@ class Listener(object):
     def receive(self) -> str:
         """Read a message.
 
-        This will wait for a inbound message on the communication channel
+        This will wait for an inbound message on the communication channel
         and return it (raw).
 
         Returns:

--- a/integration_tests/test_alarms.py
+++ b/integration_tests/test_alarms.py
@@ -111,6 +111,15 @@ def test_CRUD_2(live_c8y: CumulocityApi, sample_device: Device):  # noqa (case)
         assert all(a.text == 'another update' for a in alarms)
         assert all(a.simple_attribute == 'value' for a in alarms)
 
+        # 6) use apply_to with json
+        live_c8y.alarms.apply_to({'text': 'new text', 'add_info': 'yes'}, *alarm_ids)
+
+        # -> the new text should be in all events
+        alarms = live_c8y.alarms.get_all(**get_filter)
+        assert len(alarms) == 2
+        assert all(a.text == 'new text' for a in alarms)
+        assert all(a.add_info == 'yes' for a in alarms)
+
     finally:
         live_c8y.alarms.delete_by(**get_filter)
 
@@ -175,7 +184,7 @@ def test_filter_by_update_time(live_c8y: CumulocityApi, sample_device, sample_al
     updated_datetimes.sort()
     pivot = updated_datetimes[len(updated_datetimes)//2]
 
-    # Note: We are using additional status/severity so that we don't interfer
+    # Note: We are using additional status/severity so that we don't interfere
     # with other tests creating alarms for the same device
     before_alarms = live_c8y.alarms.get_all(source=alarm.source, updated_before=pivot,
                                             severity=alarm.severity, status=alarm.status)

--- a/integration_tests/test_binaries.py
+++ b/integration_tests/test_binaries.py
@@ -69,7 +69,7 @@ def test_CRUD(live_c8y: CumulocityApi, file_factory):
         # -> the file data matches what we have on disk
         assert file2_data == binary.read_file().decode('utf-8')
 
-        # 3) delete the binarz
+        # 3) delete the binary
         binary.delete()
 
         # -> cannot be found anymore
@@ -90,7 +90,7 @@ def test_CRUD2(live_c8y: CumulocityApi, file_factory):
     # 1) upload a binary file
     created = live_c8y.binaries.upload(file=file1_name, name='test.txt', type='text/raw')
 
-    # -> the returned managed object has all the meta data
+    # -> the returned managed object has all the metadata
     assert created.id
     assert created.is_binary
     assert created.c8y_IsBinary is not None

--- a/integration_tests/test_device_registry.py
+++ b/integration_tests/test_device_registry.py
@@ -44,8 +44,8 @@ def sample_device(live_c8y: CumulocityApi, device_registry: CumulocityDeviceRegi
     # 1) create a device connection request
     live_c8y.device_inventory.request(device_id)
 
-    # 2) continously try to accept the request
-    # the request can be accepted once there was some communication
+    # 2) continuously try to accept the request
+    # It can be accepted once there was some communication
     # we will do this asynchronously
     def await_communication_and_accept():
         # pylint: disable=bare-except

--- a/integration_tests/test_events.py
+++ b/integration_tests/test_events.py
@@ -23,7 +23,7 @@ from util.testing_util import RandomNameGenerator
 
 @pytest.fixture(scope='session')
 def sample_device(logger: Logger, live_c8y: CumulocityApi) -> Device:
-    """Provide an sample device, jsut for testing purposes."""
+    """Provide an sample device, just for testing purposes."""
 
     typename = RandomNameGenerator.random_name()
     device = Device(live_c8y, type=typename, name=typename).create()
@@ -126,6 +126,15 @@ def test_CRUD_2(live_c8y: CumulocityApi, sample_device: Device):  # noqa (case)
         events = live_c8y.events.get_all(type=typename)
         assert len(events) == 2
         assert all(e.text == 'another update' for e in events)
+
+        # 6) use apply_to with json
+        live_c8y.events.apply_to({'text': 'updated text', 'add_info': 'yes'}, *event_ids)
+
+        # -> the new text should be in all events
+        events = live_c8y.events.get_all(type=typename)
+        assert len(events) == 2
+        assert all(e.text == 'updated text' for e in events)
+        assert all(e.add_info == 'yes' for e in events)
 
     finally:
         live_c8y.events.delete(*event_ids)

--- a/integration_tests/test_measurements.py
+++ b/integration_tests/test_measurements.py
@@ -159,7 +159,11 @@ def test_select_by(live_c8y: CumulocityApi, measurement_factory, key, key_lambda
 def test_delete_by(live_c8y: CumulocityApi, measurement_factory, key, key_lambda):
     """Verify that get and delete by type works as expected."""
     measurements_for_deletion = measurement_factory(10)
-    kwargs = {key: key_lambda(measurements_for_deletion[0])}
+    kwargs = {
+        key: key_lambda(measurements_for_deletion[0]),
+        # a date or source is required as a minimum
+        'after': '1970-01-01T00:00:00Z'
+    }
 
     # 0 add some 'similar' measurements
     additional_measurements = []
@@ -197,8 +201,9 @@ def fix_sample_series_device(live_c8y: CumulocityApi, sample_device: Device) -> 
     live_c8y.measurements.create(*ms_iter)
     live_c8y.measurements.create(*ms_temps)
 
-    sample_device['c8y_SupportedSeries'] = ['c8y_Temperature.c8y_AverageTemperature',
-                                            'c8y_Iteration.c8y_Counter']
+    sample_device['c8y_SupportedSeries'] = [
+        'c8y_Temperature.c8y_AverageTemperature',
+        'c8y_Iteration.c8y_Counter']
     return sample_device.update()
 
 

--- a/samples/simple_agent.py
+++ b/samples/simple_agent.py
@@ -37,7 +37,7 @@ input("\nPress ENTER to continue.")
 # it should be used using device bootstrap credentials.
 c8y_registry = CumulocityDeviceRegistry(base_url, tenant_id, bootstrap_username, bootstrap_password)
 
-print("\nThis client will now continously query for the device credentials."
+print("\nThis client will now continuously query for the device credentials."
       "\nPlease approve the request within the Cumulocity UI.")
 # The registry provides two auxiliary functions, `await_credentials` which
 # blocks until the device registration was acknowledged and `await_connection`

--- a/samples/user_sessions.py
+++ b/samples/user_sessions.py
@@ -8,19 +8,19 @@
 This sample code demonstrates how to obtain Cumulocity user sessions (sessions
 that are run within the context of a named user).
 
-When writing a micro service for Cumulocity you always have two options to
+When writing a microservice for Cumulocity you always have two options to
 get access to Cumulocity:
 
-  a) Use a technical user' context. This is injected into the micro service
+  a) Use a technical user' context. This is injected into the microservice
      via environment variables that the c8y_api automatically deals with.
 
-  b) Use the context of whatever user accesses the micro service. The
+  b) Use the context of whatever user accesses the microservice. The
      credentials for this context must be extracted from the inbound request.
 
 The SimpleCumulocityApp and MultiTenantCumulocityApp classes can be used to
 get a user specific CumulocityApi instance using the get_user_instance
 function as illustrated below. This function will automatically extract the
-authorization information within the inboud request's headers and build a
+authorization information within the inbound request's headers and build a
 CumulocityApi instance based on that.
 """
 
@@ -37,9 +37,9 @@ c8y = SimpleCumulocityApp()
 @app.route("/info")
 def info():
     """Return user's username and devices they have access to."""
-    # The user's credentials (to access Cumulocity and to access the micro
-    # service) are part of the inbound request's headers. This is resolved
-    # automatically when using the get_user_instance function.
+    # The user's credentials (to access Cumulocity and to access the
+    # microservice) are part of the inbound request's headers. This is
+    # resolved automatically when using the get_user_instance function.
     user_c8y = c8y.get_user_instance(request.headers)
     devices_json = [{'name': d.name,
                      'id': d.id,

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     requests
     python-dateutil

--- a/tests/model/test_alarm.py
+++ b/tests/model/test_alarm.py
@@ -88,7 +88,7 @@ def test_formatting(sample_alarm: Alarm):
 
     assert 'id' not in alarm_json
     assert 'creationTime' not in alarm_json
-    assert 'firstOccuranceTime' not in alarm_json
+    assert 'firstOccurrenceTime' not in alarm_json
 
     assert alarm_json['type'] == sample_alarm.type
     assert alarm_json['source']['id'] == sample_alarm.source

--- a/tests/model/test_application.py
+++ b/tests/model/test_application.py
@@ -11,7 +11,7 @@ from c8y_api.model import Application
 
 
 def test_parsing():
-    """Verify that parsing a Application from JSON works."""
+    """Verify that parsing an Application from JSON works."""
     path = os.path.dirname(__file__) + '/application.json'
     with open(path, encoding='utf-8', mode='rt') as f:
         application_json = json.load(f)

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -199,6 +199,6 @@ def test_complexobject_instantiation_and_formatting():
     expected_diff_json = {
         'c8y_field': obj.field,
         'c8y_simple': obj.c8y_simple,
-        'c8y_complex': {'a': 'valueA', 'b': 'newB'}  # the a field is unchanged but is included nonetheless
+        'c8y_complex': {'a': 'valueA', 'b': 'newB'}  # the 'a' field is unchanged but is included nonetheless
     }
     assert obj._to_json(only_updated=True) == expected_diff_json

--- a/tests/model/test_event.py
+++ b/tests/model/test_event.py
@@ -31,7 +31,7 @@ def sample_event() -> Event:
 
 
 def test_parsing():
-    """Verify that parsing a Event from JSON works."""
+    """Verify that parsing an Event from JSON works."""
     path = os.path.dirname(__file__) + '/event.json'
     with open(path, encoding='utf-8', mode='rt') as f:
         event_json = json.load(f)
@@ -104,7 +104,7 @@ def test_updating(sample_event: Event):
     assert set(sample_event.to_diff_json().keys()) == expected_updates
 
     # 4) updated fragments are recorded
-    # Note: simple fragments can only updated using [] notation
+    # Note: simple fragments can only be updated using [] notation
     sample_event['simple_float'] = 543.21
     sample_event['simple_false'] = False
     sample_event.complex_2.level0.level1 = 'new value'

--- a/tests/model/test_inventory.py
+++ b/tests/model/test_inventory.py
@@ -3,12 +3,14 @@
 # and/or its subsidiaries and/or its affiliates and/or their licensors.
 # Use, reproduction, transfer, publication or disclosure is prohibited except
 # as specifically provided for in your License Agreement with Software AG.
+# pylint: disable=protected-access
+
 from unittest.mock import Mock
 
 import pytest
 from urllib import parse
 
-from c8y_api import CumulocityRestApi
+from c8y_api import CumulocityRestApi, CumulocityApi
 from c8y_api.model import Inventory
 from c8y_api.model._util import _QueryUtil
 from tests.utils import isolate_last_call_arg
@@ -56,7 +58,7 @@ def test_select_by_name_plus():
 
     # we expect that the following strings are part of the resource string
     expected = [
-        'query=$filter=(',
+        'query=',
         'has(FRAGMENT)',
         'name eq \'NAME\'',
         'owner eq \'OWNER\'',
@@ -67,3 +69,188 @@ def test_select_by_name_plus():
 
     for e in expected:
         assert e in url
+
+
+def _invoke_target_and_isolate_url(target, kwargs):
+    """Auxiliary function to invoke a dynamic target function on a
+    fake CumulocityApi instance and return the resource of a get call."""
+    c8y: CumulocityApi = CumulocityApi('base', 'tenant','user', 'pass')
+    c8y.get = Mock(return_value={'managedObjects': [], 'statistics': {'totalPages': 1}})
+    api, fun = target.split('.', maxsplit=1)
+    getattr(getattr(c8y, api), fun)(**kwargs)
+    return parse.unquote_plus(isolate_last_call_arg(c8y.get, 'resource', 0))
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        'inventory.get_all',
+        'inventory.get_count',
+        'device_inventory.get_all',
+        'device_inventory.get_count',
+        'group_inventory.get_all',
+        'group_inventory.get_count',
+    ])
+@pytest.mark.parametrize(
+    'name, args',
+    [
+        ('name', {
+            'kwargs': {'name': 'NAME'},
+            'expected': ["name eq 'NAME'"],
+            'not_expected': []
+        }),
+        ('type', {
+            'kwargs': {'type': 'TYPE'},
+            'expected': ['type=TYPE'],
+            'not_expected': ['and']
+        }),
+        ('owner', {
+            'kwargs': {'owner': 'OWNER'},
+            'expected': ['owner=OWNER'],
+            'not_expected': ['and']
+        }),
+        ('text', {
+            'kwargs': {'text': 'TEXT'},
+            'expected': ['text=TEXT'],
+            'not_expected': ['and']
+        }),
+        ('ids', {
+            'kwargs': {'ids': ['id1', 'id2']},
+            'expected': ['ids=id1,id2'],
+            'not_expected': ['and']
+        }),
+    ])
+def test_all_inventory_filters(target, name, args):
+    """Verify that the filter parameters are all forwarded correctly
+    end-to-end through all abstract helper methods."""
+    kwargs = args['kwargs']
+    expected = args['expected']
+    not_expected = args['not_expected']
+    url = _invoke_target_and_isolate_url(target, kwargs)
+    for e in expected:
+        assert e in url
+    for n in not_expected:
+        assert n not in url
+
+
+def execute_test_device_inventory_filters(target, args):
+    """Verify that the filter parameters are all forwarded correctly
+    end-to-end through all abstract helper methods."""
+    kwargs = args['kwargs']
+    expected = args['expected']
+    not_expected = args['not_expected']
+
+    c8y: CumulocityApi = CumulocityApi('base', 'tenant', 'user', 'pass')
+    c8y.get = Mock(return_value={'managedObjects': [], 'statistics': {'totalPages': 1}})
+    api, fun = target.split('.', maxsplit=1)
+    getattr(getattr(c8y, api), fun)(**kwargs)
+
+    url = parse.unquote_plus(isolate_last_call_arg(c8y.get, 'resource', 0))
+    for e in expected:
+        assert e in url
+    for n in not_expected:
+        assert n not in url
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        'inventory.get_all',
+        'inventory.get_count',
+    ])
+@pytest.mark.parametrize(
+    'name, args',
+    [
+        ('name', {
+            'kwargs': {'name': 'NAME'},
+            'expected': ["query=name eq 'NAME'"],
+            'not_expected': ['and']
+        }),
+        ('fragment', {
+            'kwargs': {'fragment': 'FRAGMENT'},
+            'expected': ["fragmentType=FRAGMENT"],
+            'not_expected': ['and']
+         }),
+        ('name+fragment', {
+            'kwargs': {'name': 'NAME', 'fragment': 'FRAGMENT'},
+            'expected': ["query=", "name eq 'NAME'", " and ", "has(FRAGMENT)"],
+            'not_expected': []
+         }),
+        ('query', {
+            'kwargs': {'query': 'SOMETHING'},
+            'expected': ['query=SOMETHING'],
+            'not_expected': ['and']
+         }),
+        ('query+type', {
+            'kwargs': {'query': 'SOMETHING', 'type': 'TYPE'},
+            'expected': ['query=SOMETHING'],
+            'not_expected': ['and type=', 'TYPE']
+         }),
+        ('expression', {
+            'kwargs': {'expression': 'SOMETHING'},
+            'expected': ['SOMETHING&'],
+            'not_expected': ['and']
+         }),
+        ('expression+type', {
+            'kwargs': {'expression': 'SOMETHING', 'type': 'TYPE'},
+            'expected': ['SOMETHING&'],
+            'not_expected': ['type=', 'TYPE']
+         }),
+    ])
+def test_pure_inventory_filters(target, name, args):
+    """Verify that the filter parameters are all forwarded correctly
+    end-to-end through all abstract helper methods."""
+    execute_test_device_inventory_filters(target, args)
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        'device_inventory.get_all',
+        'device_inventory.get_count',
+    ])
+@pytest.mark.parametrize(
+    'name, args',
+    [
+        ('name', {
+            'kwargs': {'name': 'NAME'},
+            'expected': ["query=", "has(c8y_IsDevice)", "and", "name eq 'NAME'"],
+            'not_expected': []
+        }),
+    ])
+def test_device_inventory_filters(target, name, args):
+    """Verify that the filter parameters are all forwarded correctly
+    end-to-end through all abstract helper methods."""
+    execute_test_device_inventory_filters(target, args)
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        'group_inventory.get_all',
+        'group_inventory.get_count',
+    ])
+@pytest.mark.parametrize(
+    'name, args',
+    [
+        ('parent', {
+            'kwargs': {'parent': 'PARENT'},
+            'expected': ['query=', 'bygroupid(PARENT)', "type eq 'c8y_DeviceSubGroup'"],
+            'not_expected': ['$filter']
+        }),
+        ('name+parent', {
+            'kwargs': {'name': 'NAME', 'parent': 'PARENT'},
+            'expected': ['query=', 'bygroupid(PARENT)', "name eq 'NAME'", "type eq 'c8y_DeviceSubGroup'"],
+            'not_expected': ['$filter']
+        }),
+        ('name+parent+query', {
+            'kwargs': {'name': 'NAME', 'parent': 'PARENT', 'query': '$func=(QUERY)'},
+            'expected': ['query=', '$filter=', 'bygroupid(PARENT)', "name eq 'NAME'",
+                         "type eq 'c8y_DeviceSubGroup'", '$func=(QUERY)'],
+            'not_expected': []
+        }),
+    ])
+def test_group_inventory_filters(target, name, args):
+    """Verify that the filter parameters are all forwarded correctly
+    end-to-end through all abstract helper methods."""
+    execute_test_device_inventory_filters(target, args)

--- a/tests/model/test_parser.py
+++ b/tests/model/test_parser.py
@@ -99,7 +99,7 @@ def test_to_json_simple(simple_object_and_mapping):
 
 def test_to_json_simple_includes(simple_object_and_mapping):
     """Verify that simple JSON rendering works using the to_json method
-    of a parser instance when an include is is specified."""
+    of a parser instance when an include is specified."""
 
     obj, mapping = simple_object_and_mapping
     parser = SimpleObjectParser(mapping)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -42,7 +42,7 @@ env_multi_tenant = {
 @mock.patch.dict(os.environ, env_per_tenant, clear=True)
 def test_per_tenant():
     """Verify that the instance will be created properly within a
-    per tenant environment"""
+    per-tenant environment"""
 
     c8y = SimpleCumulocityApp()
 
@@ -63,7 +63,7 @@ def test_per_tenant():
 
 @mock.patch.dict(os.environ, env_multi_tenant, clear=True)
 def test_multi_tenant__bootstrap_instance():
-    """Verify that the bootstrap instance will be created propertly within a
+    """Verify that the bootstrap instance will be created properly within a
     multi-tenant environment."""
 
     c8y = MultiTenantCumulocityApp().bootstrap_instance
@@ -86,7 +86,7 @@ def test_multi_tenant__bootstrap_instance():
 @mock.patch.dict(os.environ, env_multi_tenant, clear=True)
 def test_multi_tenant__caching_instances():
     """Verify that instances are cached by their tenant ID and the cache
-    is evaluated propertly."""
+    is evaluated properly."""
     # pylint: disable=protected-access
 
     # prepare a mock instance cache
@@ -132,7 +132,7 @@ def test_multi_tenant__build_from_subscriptions():
 
     with patch.object(MultiTenantCumulocityApp, '_read_subscription_auths') as read_subscriptions:
         # we mock _read_subscriptions so that we don't need an actual
-        # connection and it returns what we want
+        # connection and have a proper return value
         read_subscriptions.return_value = {'t12345': HTTPBasicAuth('username', 'password')}
 
         c8y_factory = MultiTenantCumulocityApp()
@@ -144,7 +144,7 @@ def test_multi_tenant__build_from_subscriptions():
         assert 't12345' in c8y_factory._subscribed_auths
         # -> instance is now in cache
         assert 't12345' in c8y_factory._tenant_instances
-        # -> attributes reflect was was returned by the subscriptions mock
+        # -> attributes reflect was returned by the subscriptions mock
         assert c8y.tenant_id == 't12345'
         assert c8y.username == 'username'
         assert isinstance(c8y.auth, HTTPBasicAuth)
@@ -219,7 +219,7 @@ def test_get_tenant_instance_from_headers(auth_value, tenant_id):
     c8y_factory._get_tenant_instance = Mock()
 
     # request a tenant instance from header dict
-    c8y_factory.get_tenant_instance(headers={'auTHOrization': build_auth_string(auth_value)})
+    c8y_factory.get_tenant_instance(headers={'authorization': build_auth_string(auth_value)})
     # -> the get function is called with the tenant ID
     c8y_factory._get_tenant_instance.assert_called_once_with(tenant_id)
 
@@ -260,7 +260,7 @@ def test_build_user_instance(auth_value, username):
     inbound HTTP headers."""
     # pylint: disable=protected-access
 
-    # build a Auth instance from the auth value
+    # build an Auth instance from the auth value
     auth = AuthUtil.parse_auth_string(build_auth_string(auth_value))
 
     with patch.dict(os.environ, env_per_tenant, clear=True):

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -257,7 +257,7 @@ def test_get_404():
 
 
 def test_delete_defaults(mock_c8y: CumulocityRestApi):
-    """Verify the basic funtionality of the DELETE requests."""
+    """Verify the basic functionality of the DELETE requests."""
 
     with responses.RequestsMock() as rsps:
         rsps.add(method=responses.DELETE,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -44,12 +44,12 @@ def fixture_jwt_token_bytes():
 
 
 def test_resolve_tenant_id(jwt_token_bytes):
-    """Verify that parsing the tenant ID from an Bearer authentication
+    """Verify that parsing the tenant ID from a Bearer authentication
     string works as expected."""
     assert JWT(jwt_token_bytes).tenant_id == 't12345'
 
 
 def test_resolve_username(jwt_token_bytes):
-    """Verify that parsing the username from an Bearer authentication
+    """Verify that parsing the username from a Bearer authentication
     string works as expected."""
     assert JWT(jwt_token_bytes).username == 'some.user@softwareag.com'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,7 +47,7 @@ def isolate_last_call_arg(mock: Mock, name: str, pos: int = None) -> Any:
     if len(args) > pos:
         return args[pos]
     raise KeyError(f"Argument not found: '{name}'. "
-                   f"Not given explcitely and position ({pos}) out of of bounds.")
+                   f"Not given explicitly and position ({pos}) out of of bounds.")
 
 
 def isolate_all_call_args(mock: Mock, name: str, pos: int = None) -> List[Any]:
@@ -91,7 +91,7 @@ def b64encode(auth_string: str) -> str:
 
 
 def build_auth_string(auth_value: str) -> str:
-    """Build a complete auth string from an base64 encoded auth value.
+    """Build a complete auth string from a base64 encoded auth value.
     This detects the type based on the `auth_value` contents, assuming
     that JWT tokens always start with an '{'."""
     auth_type = 'BEARER' if auth_value.startswith('ey') else 'BASIC'

--- a/util/testing_util.py
+++ b/util/testing_util.py
@@ -64,7 +64,7 @@ class RandomNameGenerator:
         """Generate a readable random name from joined random words.
 
         Args:
-            num (int):  number of random words to concactenate
+            num (int):  number of random words to concatenate
             sep (str):  concatenation separator
 
         Returns:


### PR DESCRIPTION
* The `select` and `get_all` functions now feature an `expression` parameter which allows to directly specify the entire REST API filtering expression.
* Fixed, unified and streamlined the behavior or the `query` parameter within all `select` and `get_all` functions.
* The `apply_to` functions now allow to specify the to-be-applied changes directly in JSON. 
* Various tiny code and documentation improvements. 